### PR TITLE
Remove conditional compilation for .NET Framework

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Disposables/issues/28
-Your prepared branch: issue-28-e0776703
-Your prepared working directory: /tmp/gh-issue-solver-1757828772164
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Disposables/issues/28
+Your prepared branch: issue-28-e0776703
+Your prepared working directory: /tmp/gh-issue-solver-1757828772164
+
+Proceed.

--- a/csharp/Platform.Disposables.Tests/DisposableTests.cs
+++ b/csharp/Platform.Disposables.Tests/DisposableTests.cs
@@ -42,7 +42,7 @@ namespace Platform.Disposables.Tests
             return new ProcessStartInfo
             {
                 FileName = "dotnet",
-                Arguments = $"run -p \"{projectPath}\" -f net7 \"{logPath}\" {waitForCancellation.ToString()}",
+                Arguments = $"run -p \"{projectPath}\" -f net8 \"{logPath}\" {waitForCancellation.ToString()}",
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
@@ -67,11 +67,7 @@ namespace Platform.Disposables.Tests
                 }
             }
             pathParts = newPathParts.ToArray();
-#if NET472
-            var directory = string.Join(Path.DirectorySeparatorChar.ToString(), pathParts.ToArray());
-#else
             var directory = Path.Combine(pathParts);
-#endif
             var path = Path.Combine(directory, $"{disposalOrderTestProjectName}.csproj");
             if (!Path.IsPathRooted(path))
             {


### PR DESCRIPTION
## Summary
- Removed the `#if NET472` conditional compilation directives that were using `string.Join()` for .NET Framework 4.7.2
- Simplified to use `Path.Combine()` for all target frameworks since both projects now only target .NET 8
- Updated the test runner framework target from net7 to net8

## Test plan
- [x] All existing tests pass
- [x] Verified that the path construction works correctly with `Path.Combine()` 
- [x] No special case needed since only .NET 8 is targeted

This resolves issue #28 by eliminating the special case for .NET Framework.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #28