### PR TITLE
Complete internationalization of code comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Disposables/issues/10
-Your prepared branch: issue-10-313805fd
-Your prepared working directory: /tmp/gh-issue-solver-1757848325254
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Disposables/issues/10
+Your prepared branch: issue-10-313805fd
+Your prepared working directory: /tmp/gh-issue-solver-1757848325254
+
+Proceed.

--- a/csharp/Platform.Disposables/DisposableBase.cs
+++ b/csharp/Platform.Disposables/DisposableBase.cs
@@ -60,7 +60,9 @@ namespace Platform.Disposables
         /// <para>
         /// Initializes a new <see cref="DisposableBase"/> instance.
         /// </para>
-        /// <para></para>
+        /// <para>
+        /// Инициализирует новый экземпляр <see cref="DisposableBase"/>.
+        /// </para>
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         static DisposableBase() => _currentDomain.ProcessExit += OnProcessExit;

--- a/csharp/Platform.Disposables/IDisposable.cs
+++ b/csharp/Platform.Disposables/IDisposable.cs
@@ -3,8 +3,8 @@ using System.Runtime.CompilerServices;
 namespace Platform.Disposables
 {
     /// <summary>
-    /// <para>Представляет расширенный интерфейс <see cref="System.IDisposable"/>.</para>
     /// <para>Represents an extended <see cref="System.IDisposable"/> interface.</para>
+    /// <para>Представляет расширенный интерфейс <see cref="System.IDisposable"/>.</para>
     /// </summary>
     public interface IDisposable : System.IDisposable
     {


### PR DESCRIPTION
## Summary

This PR completes the internationalization of code comments throughout the codebase by:

- **Fixed comment ordering inconsistency** in `IDisposable.cs` where Russian appeared before English (now follows English-first, Russian-second pattern)
- **Added missing Russian translation** for the static constructor documentation in `DisposableBase.cs` 
- **Ensured consistency** across all bilingual XML documentation comments

## Changes Made

1. **IDisposable.cs:6-7**: Fixed comment order to follow the standard English-first, Russian-second pattern
2. **DisposableBase.cs:59-66**: Added missing Russian translation for static constructor documentation

## Verification

- ✅ All files now consistently follow the English-first, Russian-second pattern
- ✅ No missing Russian translations remain in the codebase
- ✅ Project builds successfully with no new errors
- ✅ All documentation comments are properly internationalized

The internationalization approach used follows LinksPlatform's established pattern of bilingual XML documentation comments with parallel `<para>` tags for English and Russian text.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #10